### PR TITLE
Added tests, IPython pretty repr, and some func signature preservation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/latexify.py
+++ b/latexify.py
@@ -52,10 +52,10 @@ class LatexifyVisitor(ast.NodeVisitor):
 
   def visit_UnaryOp(self, node):
     def _wrap(child):
-      repr_ = self.visit(child)
+      latex = self.visit(child)
       if isinstance(child, ast.BinOp) and child.op in (ast.Add, ast.Sub):
-        return '(' + repr_ + ')'
-      return repr_
+        return '(' + latex + ')'
+      return latex
 
     reprs = {
         ast.UAdd: (lambda: _wrap(node.operand)),
@@ -80,13 +80,13 @@ class LatexifyVisitor(ast.NodeVisitor):
       return self.visit(child)
 
     def _wrap(child):
-      repr_ = _unwrap(child)
+      latex = _unwrap(child)
       if isinstance(child, ast.BinOp):
         cp = priority[type(child.op)] if type(child.op) in priority else 100
         pp = priority[type(node.op)] if type(node.op) in priority else 100
         if cp < pp:
-          return '(' + repr_ + ')'
-      return repr_
+          return '(' + latex + ')'
+      return latex
 
     l = node.left
     r = node.right

--- a/latexify.py
+++ b/latexify.py
@@ -25,6 +25,8 @@ class LatexifyVisitor(ast.NodeVisitor):
     builtin_callees = {
         'math.sqrt': (r'\sqrt{', '}'),
         'math.sin': (r'\sin{(', ')}'),
+        'math.cos': (r'\cos{(', ')}'),
+        'math.tan': (r'\tan{(', ')}')
     }
 
     callee_str = self.visit(node.func)
@@ -50,10 +52,10 @@ class LatexifyVisitor(ast.NodeVisitor):
 
   def visit_UnaryOp(self, node):
     def _wrap(child):
-      repr = self.visit(child)
+      repr_ = self.visit(child)
       if isinstance(child, ast.BinOp) and child.op in (ast.Add, ast.Sub):
-        return '(' + repr + ')'
-      return repr
+        return '(' + repr_ + ')'
+      return repr_
 
     reprs = {
         ast.UAdd: (lambda: _wrap(node.operand)),
@@ -78,13 +80,13 @@ class LatexifyVisitor(ast.NodeVisitor):
       return self.visit(child)
 
     def _wrap(child):
-      repr = _unwrap(child)
+      repr_ = _unwrap(child)
       if isinstance(child, ast.BinOp):
         cp = priority[type(child.op)] if type(child.op) in priority else 100
         pp = priority[type(node.op)] if type(node.op) in priority else 100
         if cp < pp:
-          return '(' + repr + ')'
-      return repr
+          return '(' + repr_ + ')'
+      return repr_
 
     l = node.left
     r = node.right
@@ -122,12 +124,38 @@ def get_latex(fn):
 
 
 def with_latex(fn):
-  class _wrapper:
+
+  class _LatexifiedFunction:
     def __init__(self, fn):
       self._fn = fn
       self._str = get_latex(fn)
+
+    @property
+    def __doc__(self):
+      return self._fn.__doc__
+
+    @__doc__.setter
+    def __doc__(self, val):
+      self._fn.__doc__ = val
+
+    @property
+    def __name__(self):
+      return self._fn.__name__
+
+    @__name__.setter
+    def __name__(self, val):
+      self._fn.__name__ = val
+
     def __call__(self, *args):
       return self._fn(*args)
+
     def __str__(self):
       return self._str
-  return _wrapper(fn)
+
+    def _repr_latex_(self):
+      """
+      Hooks into Jupyter notebook's display system.
+      """
+      return self._str
+
+  return _LatexifiedFunction(fn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+atomicwrites==1.4.0
+attrs==19.3.0
+colorama==0.4.3
+importlib-metadata==1.7.0
+more-itertools==8.4.0
+packaging==20.4
+pluggy==0.13.1
+py==1.9.0
+pyparsing==2.4.7
+pytest==5.4.3
+six==1.15.0
+wcwidth==0.2.5
+zipp==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,1 @@
-atomicwrites==1.4.0
-attrs==19.3.0
-colorama==0.4.3
-importlib-metadata==1.7.0
-more-itertools==8.4.0
-packaging==20.4
-pluggy==0.13.1
-py==1.9.0
-pyparsing==2.4.7
 pytest==5.4.3
-six==1.15.0
-wcwidth==0.2.5
-zipp==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
   author='Yusuke Oda',
   description='Generates LaTeX math description from Python functions.',
   long_description=readme,
-  python_requires='>=3.6',
+  python_requires='>=3.6, <=3.8',
   tests_require=['pytest']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import io
+from setuptools import setup
+
+
+with io.open('README.md', 'rt', encoding='utf8') as f:
+  readme = f.read()
+
+
+setup(
+  name='Latexify',
+  url='https://github.com/odashi/latexify_py',
+  py_modules=['latexify'],
+  license='Apache License 2.0',
+  author='Yusuke Oda',
+  description='Generates LaTeX math description from Python functions.',
+  long_description=readme,
+  python_requires='>=3.6',
+  tests_require=['pytest']
+)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,37 @@
+import math
+import pytest
+
+from latexify import with_latex
+
+
+def solve(a, b, c):
+  return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)
+
+
+solve_latex = r'\mathrm{solve}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
+
+
+def sinc(x):
+  if x == 0:
+    return 1
+  else:
+    return math.sin(x) / x
+
+
+sinc_latex = (
+  r'\mathrm{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ x=0 \\ \frac{\sin{(x)}}{x}, &'
+  r' \mathrm{otherwise} \end{array} \right.'
+)
+
+
+func_and_latex_str_list = [
+  (solve, solve_latex),
+  (sinc, sinc_latex)
+]
+
+
+@pytest.mark.parametrize('func, expected_latex', func_and_latex_str_list)
+def test_with_latex_to_str(func, expected_latex):
+  latexified_function = with_latex(func)
+  assert str(latexified_function) == expected_latex
+  assert latexified_function._repr_latex_() == expected_latex


### PR DESCRIPTION
- Created `.gitignore` from https://github.com/github/gitignore/blob/master/Python.gitignore
- Created `setup.py` to support `pip install -e .`
- Added `_repr_latex_()` to the wrapped class. This lets it render in Jupyter notebooks without having to wrap in `Math(str(solve))`. Now simply typing a function e.g. `solve` in a Jupyter notebook cell renders the LaTeX.
- Added some function signature preservation with `.__doc__` and `.__name__` properties in the wrapped class.
- PEP8'ed `repr` -> `repr_` to avoid namespace conflict with the builtin `repr` function.
- Added unit-tests with `pytest`. Asserts the behaviors specified in https://twitter.com/odashi_t/status/1286958318884249600, plus asserts `_repr_latex_()` returns the same string. Unit tests can be run with `pip install pytest` -> `python -m pytest ./tests` or alternatively `pip install pytest` -> `pip install -e .` -> `pytest`.
- Added more trigonometry: `tan` and `cos`.
- Added `requirements.txt`. Dependencies are solely for Pytest.

I love this module, it's superb. I hope it has a good future.