### PR TITLE
math_symbol kwarg

### DIFF
--- a/latexify/core.py
+++ b/latexify/core.py
@@ -182,7 +182,7 @@ def get_latex(fn, math_symbol=True):
   return LatexifyVisitor(math_symbol=math_symbol).visit(ast.parse(inspect.getsource(fn)))
 
 
-def with_latex(math_symbol=True):
+def with_latex(*args, math_symbol=True):
 
   class _LatexifiedFunction:
     def __init__(self, fn):
@@ -217,6 +217,7 @@ def with_latex(math_symbol=True):
       """
       return self._str
 
-  def _wrapper(fn):
-    return _LatexifiedFunction(fn)
-  return _wrapper
+  if len(args) == 1 and callable(args[0]):
+    return _LatexifiedFunction(args[0])
+  else:
+    return lambda fn: _LatexifiedFunction(fn)

--- a/latexify/core.py
+++ b/latexify/core.py
@@ -3,12 +3,11 @@
 import ast
 import math
 import inspect
-from typing import Callable
 
 
 class LatexifyVisitor(ast.NodeVisitor):
 
-  def __init__(self, math_symbol=True):
+  def __init__(self, math_symbol):
     self.math_symbol = math_symbol
     super(ast.NodeVisitor).__init__()
 
@@ -17,13 +16,16 @@ class LatexifyVisitor(ast.NodeVisitor):
       return val
     greek_and_hebrew = [
         'aleph', 'alpha', 'beta', 'beth', 'chi', 'daleth',
-        'delta', 'digamma', 'epsilon', 'eta', 'gamma', 'gimel',
+        'delta', 'digamma', 'epsilon', 'eta', 'gimel',
         'iota', 'kappa', 'lambda', 'mu', 'nu', 'omega', 'omega',
         'phi', 'pi', 'psi', 'rho', 'sigma', 'tau', 'theta',
         'upsilon', 'varepsilon', 'varkappa', 'varphi', 'varpi', 'varrho',
-        'varsigma', 'vartheta', 'xi', 'zeta'
+        'varsigma', 'vartheta', 'xi', 'zeta', 'Delta', 'Gamma',
+        'Lambda', 'Omega', 'Phi', 'Pi', 'Sigma', 'Theta',
+        'Upsilon', 'Xi',
+        # 'gamma' <-- might break with `math.gamma`; leaving out for now.
     ]
-    if val.lower() in greek_and_hebrew:
+    if val in greek_and_hebrew:
       return '{\\' + val + '}'
     else:
       return val
@@ -180,7 +182,7 @@ def get_latex(fn, math_symbol=True):
   return LatexifyVisitor(math_symbol=math_symbol).visit(ast.parse(inspect.getsource(fn)))
 
 
-def with_latex(*args, math_symbol=True):
+def with_latex(math_symbol=True):
 
   class _LatexifiedFunction:
     def __init__(self, fn):
@@ -215,7 +217,6 @@ def with_latex(*args, math_symbol=True):
       """
       return self._str
 
-  if len(args) == 1 and isinstance(args[0], Callable):
-    return _LatexifiedFunction(args[0])
-  else:
-    return lambda fn: _LatexifiedFunction(fn)
+  def _wrapper(fn):
+    return _LatexifiedFunction(fn)
+  return _wrapper

--- a/latexify/core.py
+++ b/latexify/core.py
@@ -3,9 +3,29 @@
 import ast
 import math
 import inspect
+from typing import Callable
 
 
 class LatexifyVisitor(ast.NodeVisitor):
+
+  def __init__(self, math_symbol=True):
+    self.math_symbol = math_symbol
+    super(ast.NodeVisitor).__init__()
+
+  def _parse_math_symbols(self, val: str) -> str:
+    greek_and_hebrew = [
+        'aleph', 'alpha', 'beta', 'beth', 'chi', 'daleth',
+        'delta', 'digamma', 'epsilon', 'eta', 'gamma', 'gimel',
+        'iota', 'kappa', 'lambda', 'mu', 'nu', 'omega', 'omega',
+        'phi', 'pi', 'psi', 'rho', 'sigma', 'tau', 'theta',
+        'upsilon', 'varepsilon', 'varkappa', 'varphi', 'varpi', 'varrho',
+        'varsigma', 'vartheta', 'xi', 'zeta'
+    ]
+    if self.math_symbol and val.lower() in greek_and_hebrew:
+      return '{\\' + val + '}'
+    else:
+      return '{' + val + '}'
+
   def generic_visit(self, node):
     return str(node)
 
@@ -14,7 +34,7 @@ class LatexifyVisitor(ast.NodeVisitor):
 
   def visit_FunctionDef(self, node):
     name_str = r'\operatorname{' + str(node.name) + '}'
-    arg_strs = [str(arg.arg) for arg in node.args.args]
+    arg_strs = [self._parse_math_symbols(str(arg.arg)) for arg in node.args.args]
     body_str = self.visit(node.body[0])
     return name_str + '(' + ', '.join(arg_strs) + r') \triangleq ' + body_str
 
@@ -69,7 +89,7 @@ class LatexifyVisitor(ast.NodeVisitor):
     return vstr + '.' + astr
 
   def visit_Name(self, node):
-    return str(node.id)
+    return self._parse_math_symbols(str(node.id))
 
   def visit_Num(self, node):
     return str(node.n)
@@ -154,16 +174,16 @@ class LatexifyVisitor(ast.NodeVisitor):
     return latex + self.visit(node) + r', & \mathrm{otherwise} \end{array} \right.'
 
 
-def get_latex(fn):
-  return LatexifyVisitor().visit(ast.parse(inspect.getsource(fn)))
+def get_latex(fn, math_symbol=True):
+  return LatexifyVisitor(math_symbol=math_symbol).visit(ast.parse(inspect.getsource(fn)))
 
 
-def with_latex(fn):
+def with_latex(*args, math_symbol=True):
 
   class _LatexifiedFunction:
     def __init__(self, fn):
       self._fn = fn
-      self._str = get_latex(fn)
+      self._str = get_latex(fn, math_symbol=math_symbol)
 
     @property
     def __doc__(self):
@@ -193,4 +213,7 @@ def with_latex(fn):
       """
       return self._str
 
-  return _LatexifiedFunction(fn)
+  if len(args) == 1 and isinstance(args[0], Callable):
+    return _LatexifiedFunction(args[0])
+  else:
+    return lambda fn: _LatexifiedFunction(fn)

--- a/latexify/core.py
+++ b/latexify/core.py
@@ -13,6 +13,8 @@ class LatexifyVisitor(ast.NodeVisitor):
     super(ast.NodeVisitor).__init__()
 
   def _parse_math_symbols(self, val: str) -> str:
+    if not self.math_symbol:
+      return val
     greek_and_hebrew = [
         'aleph', 'alpha', 'beta', 'beth', 'chi', 'daleth',
         'delta', 'digamma', 'epsilon', 'eta', 'gamma', 'gimel',
@@ -21,10 +23,10 @@ class LatexifyVisitor(ast.NodeVisitor):
         'upsilon', 'varepsilon', 'varkappa', 'varphi', 'varpi', 'varrho',
         'varsigma', 'vartheta', 'xi', 'zeta'
     ]
-    if self.math_symbol and val.lower() in greek_and_hebrew:
+    if val.lower() in greek_and_hebrew:
       return '{\\' + val + '}'
     else:
-      return '{' + val + '}'
+      return val
 
   def generic_visit(self, node):
     return str(node)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import io
 from setuptools import setup
+from setuptools import find_packages
 
 
 with io.open('README.md', 'rt', encoding='utf8') as f:
@@ -9,11 +10,11 @@ with io.open('README.md', 'rt', encoding='utf8') as f:
 setup(
   name='Latexify',
   url='https://github.com/odashi/latexify_py',
-  py_modules=['latexify'],
+  packages=find_packages(),
   license='Apache License 2.0',
   author='Yusuke Oda',
   description='Generates LaTeX math description from Python functions.',
   long_description=readme,
-  python_requires='>=3.6, <=3.8',
+  python_requires='>=3.6, <3.9',
   tests_require=['pytest']
 )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,7 +8,7 @@ def solve(a, b, c):
   return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)
 
 
-solve_latex = r'\mathrm{solve}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
+solve_latex = r'\operatorname{solve}({a}, {b}, {c}) \triangleq \frac{-{b} + \operatorname{{math}.sqrt}\left({b}^{2} - 4{a}{c}\right)}{2{a}}'
 
 
 def sinc(x):
@@ -19,19 +19,35 @@ def sinc(x):
 
 
 sinc_latex = (
-  r'\mathrm{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ x=0 \\ \frac{\sin{(x)}}{x}, &'
-  r' \mathrm{otherwise} \end{array} \right.'
+  r'\operatorname{sinc}({x}) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ {x}=0 \\ '
+  r'\frac{\operatorname{{math}.sin}\left({x}\right)}{{x}}, & \mathrm{otherwise} \end{array} \right.'
 )
 
 
+def xtimesbeta(x, beta):
+  return x * beta
+
+
+xtimesbeta_latex = r'\operatorname{xtimesbeta}({x}, {\beta}) \triangleq {x}{\beta}'
+xtimesbeta_latex_no_symbols = r'\operatorname{xtimesbeta}({x}, {beta}) \triangleq {x}{beta}'
+
+
 func_and_latex_str_list = [
-  (solve, solve_latex),
-  (sinc, sinc_latex)
+  (solve, solve_latex, None),
+  (sinc, sinc_latex, None),
+  (xtimesbeta, xtimesbeta_latex, True),
+  (xtimesbeta, xtimesbeta_latex_no_symbols, False),
 ]
 
 
-@pytest.mark.parametrize('func, expected_latex', func_and_latex_str_list)
-def test_with_latex_to_str(func, expected_latex):
-  latexified_function = with_latex(func)
+@pytest.mark.parametrize(
+  'func, expected_latex, math_symbol',
+  func_and_latex_str_list
+)
+def test_with_latex_to_str(func, expected_latex, math_symbol):
+  if math_symbol is None:
+    latexified_function = with_latex(func)
+  else:
+    latexified_function = with_latex(math_symbol=math_symbol)(func)
   assert str(latexified_function) == expected_latex
   assert latexified_function._repr_latex_() == expected_latex

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,7 +8,7 @@ def solve(a, b, c):
   return (-b + math.sqrt(b**2 - 4*a*c)) / (2*a)
 
 
-solve_latex = r'\operatorname{solve}({a}, {b}, {c}) \triangleq \frac{-{b} + \operatorname{{math}.sqrt}\left({b}^{2} - 4{a}{c}\right)}{2{a}}'
+solve_latex = r'\operatorname{solve}(a, b, c) \triangleq \frac{-b + \sqrt{b^{2} - 4ac}}{2a}'
 
 
 def sinc(x):
@@ -19,8 +19,8 @@ def sinc(x):
 
 
 sinc_latex = (
-  r'\operatorname{sinc}({x}) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ {x}=0 \\ '
-  r'\frac{\operatorname{{math}.sin}\left({x}\right)}{{x}}, & \mathrm{otherwise} \end{array} \right.'
+  r'\operatorname{sinc}(x) \triangleq \left\{ \begin{array}{ll} 1, & \mathrm{if} \ x=0 \\ '
+  r'\frac{\sin{\left({x}\right)}}{x}, & \mathrm{otherwise} \end{array} \right.'
 )
 
 
@@ -28,8 +28,8 @@ def xtimesbeta(x, beta):
   return x * beta
 
 
-xtimesbeta_latex = r'\operatorname{xtimesbeta}({x}, {\beta}) \triangleq {x}{\beta}'
-xtimesbeta_latex_no_symbols = r'\operatorname{xtimesbeta}({x}, {beta}) \triangleq {x}{beta}'
+xtimesbeta_latex = r'\operatorname{xtimesbeta}(x, {\beta}) \triangleq x{\beta}'
+xtimesbeta_latex_no_symbols = r'\operatorname{xtimesbeta}(x, beta) \triangleq xbeta'
 
 
 func_and_latex_str_list = [


### PR DESCRIPTION
re: issue #6 

# `math_symbol` kwarg

New behaviors:

![image](https://user-images.githubusercontent.com/53090272/88493771-f4ea9800-cf80-11ea-9ace-7b59a1446dc5.png)

Old functions remain the same, so long as variable names are not in the `greek_and_hebrew` list.

![image](https://user-images.githubusercontent.com/53090272/88493787-092e9500-cf81-11ea-8ece-257f9a09a669.png)

# Fixes to `setup.py`

Moving from a module structure to a package structure, `py_modules=['latexify']` no longer works. So I replaced it with `packages=find_packages()`.

Additionally, I tested that `<=3.8` does not work as intended. (Technically, I tested that `<=3.7` does not work, as I am on python 3.7). I am using `<3.9` now instead, which should work.