### PR TITLE
fixed setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 from setuptools import setup
-from setuptools import find_packages
 
 
 with io.open('README.md', 'rt', encoding='utf8') as f:
@@ -10,7 +9,7 @@ with io.open('README.md', 'rt', encoding='utf8') as f:
 setup(
   name='Latexify',
   url='https://github.com/odashi/latexify_py',
-  packages=find_packages(),
+  py_modules=['latexify'],
   license='Apache License 2.0',
   author='Yusuke Oda',
   description='Generates LaTeX math description from Python functions.',


### PR DESCRIPTION
I'm so sorry! 😱 😱 😱 😱 I broke `setup.py`! I was wrong: `py_modules=['latexify']` still works!

I did not notice this because the error does not come up unless you work in a totally new environment.

(When I tested my `setup.py` code, the `import latexify` just used the old install, and did not return `ModuleNotFoundError`.)

![image](https://user-images.githubusercontent.com/53090272/88602157-2e360d00-d040-11ea-9ab0-e1a77996951b.png)

However it works if I do this:

![image](https://user-images.githubusercontent.com/53090272/88602252-663d5000-d040-11ea-8d1a-3e0d59f21767.png)

I'm super sorry about this. 😱